### PR TITLE
Fix: views should explicitly depends on changings props

### DIFF
--- a/haskell/src/ReactFluxExample_Lifecycle.hs
+++ b/haskell/src/ReactFluxExample_Lifecycle.hs
@@ -21,17 +21,17 @@ exampleApp = defineControllerView "ExampleApp" exampleStore $ \(ExampleState vis
   div_ $ do
     button_ [ onClick $ \_ _ -> dispatch ToggleVisible ] "Click here!"
     div_ . elemString $ "Outside: " ++ show visible
-    lifecycleC_ $ do
+    lifecycleC_ visible $ do
         div_ . elemString $ "Inside: " ++ show visible
 
 
-lifecycleC :: ReactView ()
+lifecycleC :: Typeable a => ReactView a
 lifecycleC = defineLifecycleView "ALifecycleComponent" () lifecycleConfig
    { lRender = \_ _ -> childrenPassedToView
    }
 
-lifecycleC_ :: ReactElementM eventHandler () -> ReactElementM eventHandler ()
-lifecycleC_ = view lifecycleC ()
+lifecycleC_ :: Typeable a => a -> ReactElementM eventHandler () -> ReactElementM eventHandler ()
+lifecycleC_ = view lifecycleC
 
 data ExampleState = ExampleState
   { isVisible :: Bool


### PR DESCRIPTION
As far as I understand React/Flux only props and state will express a "need to be rendered". So in this commit I made visible part of props.